### PR TITLE
be a bit more lenient on specfile requirements

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,14 +18,9 @@ You need Java and Python 3.8. There's no package, just clone and run.
 python tlacli.py specfile.tla
 ```
 
-**You cannot pass in a path.** The following will _not_ work:
+**NOTE:** The specfile.tla must be in the working directory.
 
-```
-# Bad
-python tlacli.py ./specfile.tla
-```
-
-(IIRC this is a known issue with TLC but I haven't investigated yet. This means you can only run it while in the same directory as `specfile`. You don't need to be in the same directory as `tlacli.py`.)
+(IIRC this is a known issue with TLC but I haven't investigated yet. This means you can only run tlacli.py while in the same directory as `specfile`. You don't need to be in the same directory as `tlacli.py`.)
 
 By default, this runs `specfile.tla` with the specification `Spec`. You can change the run specification with the `--spec` flag. By default, this runs TLC with the `-terse` and `-cleanup` flags. The config file will be saved as `temporary.cfg`. You can change the filename with `--cfg-out {name}`.
 

--- a/tlacli.py
+++ b/tlacli.py
@@ -116,10 +116,10 @@ cfg_args.add_argument("--spec", "--specification", default="Spec", help="The TLA
 cfg_args.add_argument("--cfg", help="A template cfg for default values")
 
 # Extend is python 3.8 only...
-#cfg_args.add_argument("--invariant", default=[], action="extend", nargs='*', help="Adds argument as model invariant, may be specified multiple times")
-#cfg_args.add_argument("--no-invariant", default=[], action="extend", help="Invariants that should NOT be checked")
-#cfg_args.add_argument("--property", default=[], action="extend", nargs='*', help="Adds argument as model temporal property, may be specified multiple times")
-#cfg_args.add_argument("--no-property", default=[], action="extend", help="Temporal Property that should NOT be checked")
+cfg_args.add_argument("--invariant", default=[], action="extend", nargs='*', help="Adds argument as model invariant, may be specified multiple times")
+cfg_args.add_argument("--no-invariant", default=[], action="extend", help="Invariants that should NOT be checked")
+cfg_args.add_argument("--property", default=[], action="extend", nargs='*', help="Adds argument as model temporal property, may be specified multiple times")
+cfg_args.add_argument("--no-property", default=[], action="extend", help="Temporal Property that should NOT be checked")
 
 # This needs to be append so we get them in pairs matching constants to their assignments
 cfg_args.add_argument("--constant", default=[], nargs=2, action="append", help='{name} {value}')
@@ -166,7 +166,7 @@ except:
 jar_path = Path(sys.path[0], "tla2tools.jar")
 script = f"java -jar {jar_path} -workers {args.tlc_workers} -config {cfg_file} -terse -cleanup {spec_path.name}"
 print(script)
-#result = subprocess.call(script, shell=True)
+result = subprocess.call(script, shell=True)
 
 sys.exit(result)
 # Does this create an empty folder even when we cleanup the states?

--- a/tlacli.py
+++ b/tlacli.py
@@ -71,7 +71,7 @@ def construct_cfg(args=None):
 
     # This doesn't preserve ordering. MVP
     # We use list(set()) to uniquify the list
-    
+
     cfg_dict["invariants"] += args.invariant
     cfg_dict["invariants"] = unique(cfg_dict["invariants"])
 
@@ -89,7 +89,7 @@ def construct_cfg(args=None):
     out = [f"SPECIFICATION {cfg_dict['spec']}"]
     for inv in cfg_dict["invariants"]:
         out.append(f"INVARIANT {inv}")
-    
+
     for prop in cfg_dict["properties"]:
         out.append(f"PROPERTY {prop}")
 
@@ -116,10 +116,10 @@ cfg_args.add_argument("--spec", "--specification", default="Spec", help="The TLA
 cfg_args.add_argument("--cfg", help="A template cfg for default values")
 
 # Extend is python 3.8 only...
-cfg_args.add_argument("--invariant", default=[], action="extend", nargs='*', help="Adds argument as model invariant, may be specified multiple times")
-cfg_args.add_argument("--no-invariant", default=[], action="extend", help="Invariants that should NOT be checked")
-cfg_args.add_argument("--property", default=[], action="extend", nargs='*', help="Adds argument as model temporal property, may be specified multiple times")
-cfg_args.add_argument("--no-property", default=[], action="extend", help="Temporal Property that should NOT be checked")
+#cfg_args.add_argument("--invariant", default=[], action="extend", nargs='*', help="Adds argument as model invariant, may be specified multiple times")
+#cfg_args.add_argument("--no-invariant", default=[], action="extend", help="Invariants that should NOT be checked")
+#cfg_args.add_argument("--property", default=[], action="extend", nargs='*', help="Adds argument as model temporal property, may be specified multiple times")
+#cfg_args.add_argument("--no-property", default=[], action="extend", help="Temporal Property that should NOT be checked")
 
 # This needs to be append so we get them in pairs matching constants to their assignments
 cfg_args.add_argument("--constant", default=[], nargs=2, action="append", help='{name} {value}')
@@ -152,14 +152,21 @@ print(cfg)
 with open(cfg_file, 'w') as f:
     f.write(cfg)
 
+# TLAtools requires the filename to be bare, without path, in the current working directory. If these things are true,
+spec_path = Path(args.Specfile)
+try:
+    if not spec_path.samefile(Path.cwd() / spec_path.name):
+        print("Specfile must exist in the current directory.")
+        sys.exit(1)
+except:
+    print("Specfile must exist in the current directory.")
+    sys.exit(1)
+
 # Actually run stuff
-
-
-
 jar_path = Path(sys.path[0], "tla2tools.jar")
-script = f"java -jar {jar_path} -workers {args.tlc_workers} -config {cfg_file} -terse -cleanup {args.Specfile}"
+script = f"java -jar {jar_path} -workers {args.tlc_workers} -config {cfg_file} -terse -cleanup {spec_path.name}"
 print(script)
-result = subprocess.call(script, shell=True)
+#result = subprocess.call(script, shell=True)
 
 sys.exit(result)
 # Does this create an empty folder even when we cleanup the states?


### PR DESCRIPTION
This doesn't remove the need to be in the current working directory, but _does_ remove the path if it references the same file as in cwd. Will also fail if the file doesn't actually exist. 