### PR TITLE
Fix specifying a spec in the cli args

### DIFF
--- a/src/tlacli/cfg.py
+++ b/src/tlacli/cfg.py
@@ -18,7 +18,7 @@ class CFG:
     """
     Internal representation of a .cfg.
     """
-    spec: str = "Spec"
+    spec: t.Optional[str] = None
     invariants: ss = field(default_factory=set)
     properties: ss = field(default_factory=set)
     constants: t.Dict[str, str] = field(default_factory=dict)
@@ -34,7 +34,9 @@ class CFG:
         out.invariants = self.invariants | other.invariants
         out.properties = self.properties | other.properties
         out.model_values = self.model_values | other.model_values
-        
+
+        out.spec = other.spec or self.spec
+
         # if two CFGs def the same constant, we use the _second_ one
         out.constants.update(self.constants)
         out.constants.update(other.constants)
@@ -43,7 +45,8 @@ class CFG:
 def format_cfg(cfg: CFG) -> str:
     """Convert a CFG into a format that can be read by TLC."""
     # XXX temporarily just using sorted to enforce ordering
-    out = [f"SPECIFICATION {cfg.spec}"]
+    spec = cfg.spec or "Spec"
+    out = [f"SPECIFICATION {spec}"]
     for inv in sorted(cfg.invariants):
         out.append(f"INVARIANT {inv}")
 

--- a/src/tlacli/tools/tlc.py
+++ b/src/tlacli/tools/tlc.py
@@ -95,7 +95,7 @@ def setup(parser: _SubParsersAction) -> None:
     tlc_args = parser_tlc.add_argument_group("tlc_args", "Runtime values for the TLC model checker")
     # https://lamport.azurewebsites.net/tla/tlc-options.html
 
-    cfg_args.add_argument("--spec", "--specification", default="Spec", help="The TLA+ specification operator, defaults to Spec")
+    cfg_args.add_argument("--spec", "--specification", default=None, help="The TLA+ specification operator, defaults to Spec")
     cfg_args.add_argument("--cfg", help="A template cfg for default values")
 
     # action=extend is python 3.8 only...


### PR DESCRIPTION
The custom spec wasn't getting the 'prefer-other' semantics of CFG#merge, so any spec specified by `--specification` in the args was getting ignored in favour of the default value of "Spec" from the base cfg.

Fixed by leaving it as None by default and merging as `other.spec or self.spec`, moving the "Spec" fallback to the last possible moment (`format_cfg`)